### PR TITLE
sdm660-common: Disable entropy contribution on MMC devices

### DIFF
--- a/rootdir/etc/init.qcom.post_boot.sh
+++ b/rootdir/etc/init.qcom.post_boot.sh
@@ -382,9 +382,9 @@ function configure_zram_parameters() {
 }
 
 function configure_read_ahead_kb_values() {
-    echo 128 > /sys/block/mmcblk0/bdi/read_ahead_kb
+    echo 0 > /sys/block/mmcblk0/queue/add_random
     echo 128 > /sys/block/mmcblk0/queue/read_ahead_kb
-    echo 128 > /sys/block/mmcblk0rpmb/bdi/read_ahead_kb
+    echo 0 > /sys/block/mmcblk0rpmb/queue/add_random
     echo 128 > /sys/block/mmcblk0rpmb/queue/read_ahead_kb
     echo 128 > /sys/block/dm-0/queue/read_ahead_kb
     echo 128 > /sys/block/dm-1/queue/read_ahead_kb


### PR DESCRIPTION
* According to the kernel commit: https://github.com/LineageOS/android_kernel_xiaomi_sdm660/commit/b277da0
* kernel commit:
  block: disable entropy contributions for nonrot devices

  Clear QUEUE_FLAG_ADD_RANDOM in all block drivers that set
  QUEUE_FLAG_NONROT.

  Historically, all block devices have automatically made entropy
  contributions.  But as previously stated in commit e2e1a14 ("block: add
  sysfs knob for turning off disk entropy contributions"):
     - On SSD disks, the completion times aren't as random as they
       are for rotational drives. So it's questionable whether they
       should contribute to the random pool in the first place.
     - Calling add_disk_randomness() has a lot of overhead.

  There are more reliable sources for randomness than non-rotational block
  devices.  From a security perspective it is better to err on the side of
  caution than to allow entropy contributions from unreliable "random"
  sources.

* Our device is using eMMC5.1 (cmdq),
  CAF introduced this commit in the kernel: https://github.com/LineageOS/android_kernel_xiaomi_sdm660/commit/6d1be7e
  mmc_cmdq_setup_queue in changed
  drivers/mmc/card/queue.c only marked non-spinning disks
  According to the above mentioned entropy
  contribution only applies to non-spinning disks, so
  we disable eMMC entropy contribution to reduce overhead.

* Aquarius223: Also clean up the bdi part of the changes,
               it shares a sysfs with the queue node.

Fixes: 662f9d360 ("sdm660-common: Use 128kb readahead for all targets")
Change-Id: I363fa19fa1e436163eb1dbd65af70cabdbd96be4